### PR TITLE
Add type cast decoded buffer to number[]

### DIFF
--- a/src/utils/keyUtils.ts
+++ b/src/utils/keyUtils.ts
@@ -69,23 +69,23 @@ function getAddress(publicKey: Buffer): Buffer {
 // NOTE: this only works with a compressed public key (33 bytes)
 export function getAccAddress(publicKey: Buffer): string {
   const words = getAddress(publicKey)
-  return bech32.encode(accPrefix, words)
+  return bech32.encode(accPrefix, (words as unknown) as number[])
 }
 
 // NOTE: this only works with a compressed public key (33 bytes)
 export function getValAddress(publicKey: Buffer): string {
   const words = getAddress(publicKey)
-  return bech32.encode(valPrefix, words)
+  return bech32.encode(valPrefix, (words as unknown) as number[])
 }
 
 export function convertValAddressToAccAddress(address: string): string {
   const { words } = bech32.decode(address)
-  return bech32.encode(accPrefix, words)
+  return bech32.encode(accPrefix, (words as unknown) as number[])
 }
 
 export function convertAccAddressToValAddress(address: string): string {
   const { words } = bech32.decode(address)
-  return bech32.encode(valPrefix, words)
+  return bech32.encode(valPrefix, (words as unknown) as number[])
 }
 
 export function generateMnemonic(): string {


### PR DESCRIPTION
I do not know why number[] type is used as an argument in `buffer.encode` method interface but here is a code that makes it run the lib.